### PR TITLE
Add item physicalDescription enum list

### DIFF
--- a/Controlled_Vocabularies/item_2_physicalDescription.json
+++ b/Controlled_Vocabularies/item_2_physicalDescription.json
@@ -1,0 +1,9 @@
+{
+  "$id": "item_2_physicalDescription",
+  "enum": [
+    "Film",
+    "Analog Video",
+    "Digital",
+    "Digital Video"
+  ]
+}


### PR DESCRIPTION
This adds the enum list of physical_description parameter of movie_db_dataobjects dtr data object.

Please refer to the following links for details about the data objects: 
https://dtr-test.pidconsortium.eu/#objects/21.T11148/b0047df54c686b9df82a 
https://dtr-test.pidconsortium.eu/#objects/21.T11148/0fab4d3181e8ce0d91d2